### PR TITLE
docs: update installation URLs to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Stop copy-pasting between AI models. Roundtable AI is a local MCP server that le
 
 ```bash
 # Install Roundtable AI
-pip install roundtable-ai
+pip install git+https://github.com/allwiya/roundtable.git@v0.5.0
 
 # Check available AI tools
 roundtable-ai --check
@@ -227,16 +227,16 @@ Aggregate findings into a performance optimization plan with measurable improvem
 
 ## Installation
 
-### Using pip (Standard)
+### Using pip (from GitHub)
 
 ```bash
-pip install roundtable-ai
+pip install git+https://github.com/allwiya/roundtable.git@v0.5.0
 ```
 
 ### Using UV/UVX (Recommended for faster installs)
 
 ```bash
-uvx roundtable-ai@latest
+uvx --from git+https://github.com/allwiya/roundtable.git@v0.5.0 roundtable-ai
 ```
 
 ## IDE Integration


### PR DESCRIPTION
Updates README with GitHub release URLs for v0.5.0

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates README install instructions to pull v0.5.0 directly from the GitHub release. Replaces pip/uvx examples with git-based commands to pin the version and avoid stale PyPI installs.

<sup>Written for commit 0ba2bae632f5da8cbf2fac5f371892bb6e97d7cc. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

